### PR TITLE
fix: navegacao menu

### DIFF
--- a/src/main/java/br/com/duckchain/Main.java
+++ b/src/main/java/br/com/duckchain/Main.java
@@ -17,19 +17,19 @@ public class Main
                     System.out.println("Encerrando programa...");
                     break;
                 case 1:
-                    UsuarioView.main(args);
+                    UsuarioView.executar(scanner);
                     break;
                 case 2:
-                    ContaView.main(args);
+                    ContaView.executar(scanner);
                     break;
                 case 3:
-                    MoedaView.main(args);
+                    MoedaView.executar(scanner);
                     break;
                 case 4:
-                    TransacaoView.main(args);
+                    TransacaoView.executar(scanner);
                     break;
                 case 5:
-                    TransferenciaView.main(args);
+                    TransferenciaView.executar(scanner);
                     break;
                 default:
                     System.out.println("Opção inválida. Tente novamente...");

--- a/src/main/java/br/com/duckchain/view/ContaView.java
+++ b/src/main/java/br/com/duckchain/view/ContaView.java
@@ -11,7 +11,11 @@ public class ContaView {
 
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
+        executar(scanner);
+        scanner.close();
+    }
 
+    public static void executar(Scanner scanner) {
         ContaDao dao;
         try {
             dao = new ContaDao();
@@ -43,8 +47,6 @@ public class ContaView {
             dao.fecharConexao();
         } catch (SQLException e) {
             System.err.println("Erro ao conectar ao banco de dados: " + e.getMessage());
-        } finally {
-            scanner.close();
         }
     }
 

--- a/src/main/java/br/com/duckchain/view/MoedaView.java
+++ b/src/main/java/br/com/duckchain/view/MoedaView.java
@@ -8,6 +8,11 @@ import java.util.*;
 public class MoedaView {
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
+        executar(scanner);
+        scanner.close();
+    }
+
+    public static void executar(Scanner scanner) {
         MoedaDao dao;
         try{
             dao = new MoedaDao();
@@ -38,10 +43,9 @@ public class MoedaView {
             dao.fecharConexao();
         }catch (SQLException e){
             System.err.println("Erro ao conectar ao banco de dados: " + e.getMessage());
-        }finally {
-            scanner.close();
         }
     }
+
     private static void cadastrar(Scanner scanner, MoedaDao dao){
         System.out.println("Digite o id da moeda:");
         int idMoeda = scanner.nextInt();

--- a/src/main/java/br/com/duckchain/view/TransacaoView.java
+++ b/src/main/java/br/com/duckchain/view/TransacaoView.java
@@ -12,7 +12,12 @@ public class TransacaoView {
 
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
+        executar(scanner);
+        scanner.close();
 
+    }
+
+    public  static void executar(Scanner scanner) {
         TransacaoDao dao;
         try{
             dao = new TransacaoDao();
@@ -34,10 +39,9 @@ public class TransacaoView {
             dao.fecharConexao();
         } catch (SQLException e) {
             System.err.println("Erro ao conectar ao banco de dados: " + e.getMessage());
-        } finally {
-            scanner.close();
         }
     }
+
     private static void cadastrar(Scanner scanner, TransacaoDao dao) {
         try {
             System.out.print("ID da Conta: ");

--- a/src/main/java/br/com/duckchain/view/TransferenciaView.java
+++ b/src/main/java/br/com/duckchain/view/TransferenciaView.java
@@ -13,7 +13,12 @@ public class TransferenciaView {
 
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
+        executar(scanner);
+        scanner.close();
 
+    }
+
+    public static void executar(Scanner scanner) {
         TransferenciaDao dao;
         try{
             dao = new TransferenciaDao();
@@ -21,24 +26,23 @@ public class TransferenciaView {
             do {
                 System.out.println("--------------------------------\nTRANSFERENCIA - MENU:\n 1 - CADASTRAR TRANSFERENCIA\n 0 - SAIR \n--------------------------------\nDigite o número da função desejada:");
                 escolha = scanner.nextInt();
-                    switch (escolha){
-                        case 0:
-                            System.out.println("Saindo e retornando ao MENU GERAL...");
-                            break;
-                        case 1:
-                            cadastrar(scanner, dao);
-                            break;
-                        default:
-                            System.out.println("Opção inválida. Tente novamente...");
-                    }
-                } while (escolha !=0);
-                    dao.fecharConexao();
-            } catch (SQLException e) {
-                System.err.println("Erro ao conectar ao banco de dados: " + e.getMessage());
-        } finally {
-            scanner.close();
+                switch (escolha){
+                    case 0:
+                        System.out.println("Saindo e retornando ao MENU GERAL...");
+                        break;
+                    case 1:
+                        cadastrar(scanner, dao);
+                        break;
+                    default:
+                        System.out.println("Opção inválida. Tente novamente...");
+                }
+            } while (escolha !=0);
+            dao.fecharConexao();
+        } catch (SQLException e) {
+            System.err.println("Erro ao conectar ao banco de dados: " + e.getMessage());
         }
     }
+
     private static void cadastrar(Scanner scanner, TransferenciaDao dao) {
         try {
             System.out.print("ID da Conta de Origem: ");

--- a/src/main/java/br/com/duckchain/view/UsuarioView.java
+++ b/src/main/java/br/com/duckchain/view/UsuarioView.java
@@ -13,6 +13,11 @@ public class UsuarioView {
 
     public static void main(String[] args) {
         Scanner scanner = new Scanner(System.in);
+        executar(scanner);
+        scanner.close();
+    }
+
+    public static void executar(Scanner scanner) {
         UsuarioDao dao;
         try {
             dao = new UsuarioDao();
@@ -40,8 +45,6 @@ public class UsuarioView {
             dao.fecharConexao();
         } catch (SQLException e) {
             System.err.println("Erro ao conectar ao banco de dados: " + e.getMessage());
-        } finally {
-            scanner.close();
         }
     }
 


### PR DESCRIPTION
O problema na navegação do menu era por causa do Scanner, apesar de cada classe ter sua própria instancia do scanner, no java ele é global, quando a classe UsuarioView executava o scanner.close no final, ela encerrava o scanner da main também.

A solução foi criar métodos nas classes que recebem por parâmetro o scanner e o main principal chama esse novo método, e para manter a opção de testar diretamente as classes pelo main interno delas, deixei elas criando a instancia do scanner mas executando o mesmo método que a main principal executa.